### PR TITLE
refactor hash function and nlp example

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+BasedOnStyle: Chromium
+Language: Cpp
+MaxEmptyLinesToKeep: 3
+IndentCaseLabels: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+TabWidth: 4
+UseTab: Never
+IndentWidth: 4
+BreakBeforeBraces: Linux
+AccessModifierOffset: -4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+# fig/hash.png
+# fig/scalability.png
+data/*.dat
+fig/*.png
+generate
+nlp_v
+speed

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,8 @@ plot: $(GENERATE)
 	$(GP) $(PHASH)
 	$(GP) $(PSCAL)
 
+format:
+	clang-format -i *.[ch]
+
 clean:
 	rm *.o $(NLP) $(SPEED) $(GENERATE)

--- a/generate.c
+++ b/generate.c
@@ -56,9 +56,9 @@ int main(int argc, char *argv[]) {
               for (int si = 0; si < s_size; si++)
                   s[si] = (char)(rand() % 92 + 33); 
               s[s_size] = '\0';
-              printf("key : \"%s\", value : %d\n", s, shash(s, bits));
-              fprintf(fout_hash, "%d\n", shash(s, bits));
-              map_adds(hmap, s, NULL);
+              printf("key : \"%s\", value : %d\n", s, hash(s, bits));
+              fprintf(fout_hash, "%d\n", hash(s, bits));
+              map_add(hmap, s, NULL);
               free(s);
           }
       }

--- a/generate.c
+++ b/generate.c
@@ -1,10 +1,11 @@
-#include "hashtable.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include "hashtable.h"
 
 struct timespec time_diff(struct timespec start, struct timespec end);
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
     // hash major code
 
     if (argc < 3) {
@@ -12,13 +13,16 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    int bits = atoi(argv[1]), basic_size = atoi(argv[2]), iteration_num = argc > 3 ? atoi(argv[3]) : 1;
-    printf("hash table size = %d, basic num of key = %d, iteration num = %d .\n", MAP_HASH_SIZE(bits), basic_size, iteration_num);
+    int bits = atoi(argv[1]), basic_size = atoi(argv[2]),
+        iteration_num = argc > 3 ? atoi(argv[3]) : 1;
+    printf(
+        "hash table size = %d, basic num of key = %d, iteration num = %d .\n",
+        MAP_HASH_SIZE(bits), basic_size, iteration_num);
 
     FILE *fout_scal;
     if (!(fout_scal = fopen("dat/scalability.dat", "w"))) {
-      printf("file open error!\n");
-      exit(0);
+        printf("file open error!\n");
+        exit(0);
     }
 
     srand(time(NULL));
@@ -26,62 +30,63 @@ int main(int argc, char *argv[]) {
     int shift_num = 12;
 
     for (int iter = 1; iter <= iteration_num; iter++) {
+        map_t *hmap = map_init(bits, 's');
+        if (!hmap) {
+            printf("hash map malloc error!\n");
+            exit(0);
+        }
 
-      map_t* hmap = map_init(bits, 's');
-      if (!hmap) {
-          printf("hash map malloc error!\n");
-          exit(0);
-      }
-      
-      FILE *fout_hash;
-      char *f_hash = (char *)malloc(sizeof(char) * 32);
-      if (!f_hash) {
-        printf("filename malloc error!\n");
-        exit(0);
-      }
-      int size = iter * basic_size;
+        FILE *fout_hash;
+        char *f_hash = (char *) malloc(sizeof(char) * 32);
+        if (!f_hash) {
+            printf("filename malloc error!\n");
+            exit(0);
+        }
+        int size = iter * basic_size;
 
-      sprintf(f_hash, "dat/generate_%d.dat", size);
+        sprintf(f_hash, "dat/generate_%d.dat", size);
 
-      if (!(fout_hash = fopen(f_hash, "w"))) {
-          printf("file open error!\n");
-          exit(0);
-      }
+        if (!(fout_hash = fopen(f_hash, "w"))) {
+            printf("file open error!\n");
+            exit(0);
+        }
 
-      printf("iteration %d ...\n", iter);
-      for (int i = 0; i < size; i++) {
-          int s_size = 3 + rand() % 27;
-          char *s = (char *)malloc(sizeof(char) * (s_size + 1));
-          if (s) {
-              for (int si = 0; si < s_size; si++)
-                  s[si] = (char)(rand() % 92 + 33); 
-              s[s_size] = '\0';
-              printf("key : \"%s\", value : %d\n", s, hash(s, bits));
-              fprintf(fout_hash, "%d\n", hash(s, bits));
-              map_add(hmap, s, NULL);
-              free(s);
-          }
-      }
+        printf("iteration %d ...\n", iter);
+        for (int i = 0; i < size; i++) {
+            int s_size = 3 + rand() % 27;
+            char *s = (char *) malloc(sizeof(char) * (s_size + 1));
+            if (s) {
+                for (int si = 0; si < s_size; si++)
+                    s[si] = (char) (rand() % 92 + 33);
+                s[s_size] = '\0';
+                printf("key : \"%s\", value : %d\n", s, hash(s, bits));
+                fprintf(fout_hash, "%d\n", hash(s, bits));
+                map_add(hmap, s, NULL);
+                free(s);
+            }
+        }
 
-      // count ratio
-      struct hmap_info * info = map_get_info(hmap);
-      if (info) {
-        fprintf(fout_scal, "%.2f %f %f %f %f\n", info->load_factor, info->empty_rate, info->exactly_one_rate, info->more_than_one_rate, info->collision_rate);
-        printf("============== result ==============\n");
-        printf("| num of key = %d\n", info->key_cnt);
-        printf("| load factor = %f\n", info->load_factor);
-        printf("| not-used rate = %f%%\n", info->empty_rate);
-        printf("| exactly-one rate = %f%%\n", info->exactly_one_rate);
-        printf("| more-than-one rate = %f%%\n", info->more_than_one_rate);
-        printf("| collision rate = %f%%\n", info->collision_rate);
-        printf("====================================\n");
-      }
+        // count ratio
+        struct hmap_info *info = map_get_info(hmap);
+        if (info) {
+            fprintf(fout_scal, "%.2f %f %f %f %f\n", info->load_factor,
+                    info->empty_rate, info->exactly_one_rate,
+                    info->more_than_one_rate, info->collision_rate);
+            printf("============== result ==============\n");
+            printf("| num of key = %d\n", info->key_cnt);
+            printf("| load factor = %f\n", info->load_factor);
+            printf("| not-used rate = %f%%\n", info->empty_rate);
+            printf("| exactly-one rate = %f%%\n", info->exactly_one_rate);
+            printf("| more-than-one rate = %f%%\n", info->more_than_one_rate);
+            printf("| collision rate = %f%%\n", info->collision_rate);
+            printf("====================================\n");
+        }
 
-      fclose(fout_hash);
-      free(f_hash);
-      map_deinits(hmap);
+        fclose(fout_hash);
+        free(f_hash);
+        map_deinits(hmap);
     }
-    
+
     fclose(fout_scal);
     return 0;
 }

--- a/hash.h
+++ b/hash.h
@@ -1,17 +1,17 @@
 #include <stdio.h>
 
-struct hlist_node { 
-    struct hlist_node *next, **pprev; 
+struct hlist_node {
+    struct hlist_node *next, **pprev;
 };
 
 struct hlist_head {
-    struct hlist_node *first; 
+    struct hlist_node *first;
 };
 
-typedef struct { 
-    char type; // 'i' for integer hashing, 's' for string hashing
-    int bits; 
-    struct hlist_head *ht; 
+typedef struct {
+    char type;  // 'i' for integer hashing, 's' for string hashing
+    int bits;
+    struct hlist_head *ht;
 } map_t;
 
 struct hash_key {
@@ -21,31 +21,33 @@ struct hash_key {
 };
 
 struct hash_skey {
-    char * skey;
+    char *skey;
     void *data;
     struct hlist_node node;
 };
 
-#define GOLDEN_RATIO_32 0x61C88647 //1640531526.5
+#define GOLDEN_RATIO_32 0x61C88647  // 1640531526.5
 #define GOLDEN_RATIO_64 0x61C8864680B583EBull
 
-static inline unsigned int ihash(unsigned int val, unsigned int bits) {
+static inline unsigned int ihash(unsigned int val, unsigned int bits)
+{
     return (val * GOLDEN_RATIO_32) >> (32 - bits);
 }
 
-static inline unsigned int shash(const char *str, unsigned int bits) {
+static inline unsigned int shash(const char *str, unsigned int bits)
+{
     if (!str)
         return 0;
 
     unsigned int ret = 1, len = strlen(str);
-    for (int i = 0; i < len; i++) 
+    for (int i = 0; i < len; i++)
         ret = (ret * str[i] * GOLDEN_RATIO_32) >> (32 - bits);
 
     return ret;
 }
 
 #define hash(val, bits) \
-_Generic((val), \
+    _Generic((val), \
     unsigned int: ihash, \
     int: ihash, \
     const char *: shash, \

--- a/hash.h
+++ b/hash.h
@@ -29,7 +29,7 @@ struct hash_skey {
 #define GOLDEN_RATIO_32 0x61C88647 //1640531526.5
 #define GOLDEN_RATIO_64 0x61C8864680B583EBull
 
-static inline unsigned int hash(unsigned int val, unsigned int bits) {
+static inline unsigned int ihash(unsigned int val, unsigned int bits) {
     return (val * GOLDEN_RATIO_32) >> (32 - bits);
 }
 
@@ -43,3 +43,11 @@ static inline unsigned int shash(const char *str, unsigned int bits) {
 
     return ret;
 }
+
+#define hash(val, bits) \
+_Generic((val), \
+    unsigned int: ihash, \
+    int: ihash, \
+    const char *: shash, \
+    char *: shash \
+)(val, bits)

--- a/hash.h
+++ b/hash.h
@@ -37,8 +37,8 @@ static inline unsigned int shash(const char *str, unsigned int bits) {
     if (!str)
         return 0;
 
-    unsigned int ret = 1;
-    for (int i = 0; i < strlen(str); i++) 
+    unsigned int ret = 1, len = strlen(str);
+    for (int i = 0; i < len; i++) 
         ret = (ret * str[i] * GOLDEN_RATIO_32) >> (32 - bits);
 
     return ret;

--- a/hashtable.h
+++ b/hashtable.h
@@ -1,16 +1,15 @@
-#include <stddef.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "hash.h"
 
 // util
-#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int:(-!!(e)); })))
+#define BUILD_BUG_ON_ZERO(e) ((int) (sizeof(struct { int : (-!!(e)); })))
 #define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
 #define __must_be_array(a) BUILD_BUG_ON_ZERO(__same_type((a), &(a)[0]))
-#define WRITE_ONCE(var, val) \
-    (*((volatile typeof(val) *)(&(var))) = (val))
+#define WRITE_ONCE(var, val) (*((volatile typeof(val) *) (&(var))) = (val))
 
 // for size counting
 #define MAP_HASH_SIZE(bits) (1 << bits)
@@ -21,21 +20,19 @@
 // for iteration
 #define HLIST_FOR_EACH(tmp, head) \
     for (struct hlist_node *tmp = head; tmp; tmp = tmp->next)
-#define HMAP_FOR_EACH(heah, map, index) \
-    int index = 0;\
-    for (struct hlist_node *heah = (map->ht)[index].first; index < MAP_HASH_SIZE(map->bits); heah = (map->ht)[++index].first)
+#define HMAP_FOR_EACH(heah, map, index)                    \
+    int index = 0;                                         \
+    for (struct hlist_node *heah = (map->ht)[index].first; \
+         index < MAP_HASH_SIZE(map->bits); heah = (map->ht)[++index].first)
 
 // check type
-#define TYPE_CONSISTENT(map, t) \
-    (map && map->type == t) ? 1 : 0
+#define TYPE_CONSISTENT(map, t) (map && map->type == t) ? 1 : 0
 
-#define container_of(ptr, type, member)                            \
-    __extension__({                                                \
-        const __typeof__(((type *) 0)->member) *__pmember = (ptr); \
-        (type *) ((char *) __pmember - offsetof(type, member));    \
+#define container_of(ptr, type, member)               \
+    ({                                                \
+        void *__mptr = (void *) (ptr);                \
+        ((type *) (__mptr - offsetof(type, member))); \
     })
-
-
 
 struct hmap_info {
     int key_cnt;
@@ -46,16 +43,51 @@ struct hmap_info {
     float collision_rate;
 };
 
-map_t *map_init(int bits, char type) {
-    map_t *map = (map_t *)malloc(sizeof(map_t));
+static struct hash_key *find_ikey(map_t *map, int key);
+static struct hash_skey *find_skey(map_t *map, char *skey);
+void *map_geti(map_t *map, int key);
+void *map_gets(map_t *map, char *skey);
+void map_addi(map_t *map, int key, void *data);
+void map_adds(map_t *map, char *skey, void *data);
+void map_deli(map_t *map, int key);
+void map_dels(map_t *map, char *skey);
+
+#define find_key(map, key) \
+    _Generic((key), \
+        int : find_ikey,  \
+        char * : find_skey \
+    )(map, key) \
+
+#define map_get(map, key) \
+    _Generic((key), \
+        int : map_geti, \
+        char * : map_gets \
+    )(map, key) \
+
+#define map_add(map, key, data) \
+    _Generic((key), \
+        int : map_addi, \
+        char * : map_adds \
+    )(map, key, data) \
+
+#define map_del(map, key) \
+    _Generic((key), \
+        int : map_deli, \
+        char * : map_dels \
+    )(map, key) \
+
+map_t *map_init(int bits, char type)
+{
+    map_t *map = (map_t *) malloc(sizeof(map_t));
     if (!map)
         return NULL;
 
     map->bits = bits;
-    map->type = type; // assign type (int or char *)
-    map->ht = (struct hlist_head*)malloc(sizeof(struct hlist_head) * MAP_HASH_SIZE(map->bits));
+    map->type = type;  // assign type (int or char *)
+    map->ht = (struct hlist_head *) malloc(sizeof(struct hlist_head) *
+                                           MAP_HASH_SIZE(map->bits));
     if (map->ht) {
-        for (int i = 0; i < MAP_HASH_SIZE(map->bits); i++){
+        for (int i = 0; i < MAP_HASH_SIZE(map->bits); i++) {
             (map->ht)[i].first = NULL;
         }
     } else {
@@ -65,20 +97,23 @@ map_t *map_init(int bits, char type) {
     return map;
 }
 
-static struct hash_key *find_ikey(map_t *map, int key) {
+static struct hash_key *find_ikey(map_t *map, int key)
+{
     assert(TYPE_CONSISTENT(map, 'i'));
-    struct hlist_head *head = &(map->ht)[hash(key, map->bits)]; //change
+    struct hlist_head *head = &(map->ht)[hash(key, map->bits)];  // change
     for (struct hlist_node *p = head->first; p; p = p->next) {
-        struct hash_key *kn = (struct hash_key *)container_of(p, struct hash_key, node);
+        struct hash_key *kn =
+            (struct hash_key *) container_of(p, struct hash_key, node);
         if (kn->key == key)
             return kn;
     }
     return NULL;
 }
 
-static struct hash_skey *find_skey(map_t *map, char * skey) {
+static struct hash_skey *find_skey(map_t *map, char *skey)
+{
     assert(TYPE_CONSISTENT(map, 's'));
-    struct hlist_head *head = &(map->ht)[hash(skey, map->bits)]; //change
+    struct hlist_head *head = &(map->ht)[hash(skey, map->bits)];  // change
     for (struct hlist_node *p = head->first; p; p = p->next) {
         struct hash_skey *kn = container_of(p, struct hash_skey, node);
         if (strcmp(kn->skey, skey) == 0)
@@ -86,13 +121,6 @@ static struct hash_skey *find_skey(map_t *map, char * skey) {
     }
     return NULL;
 }
-
-#define find_key(map, key)  \
-    _Generic((key), \
-        int: find_ikey, \
-        char*: find_skey\
-    )(map, key)\
-
 
 void *map_geti(map_t *map, int key)
 {
@@ -102,20 +130,13 @@ void *map_geti(map_t *map, int key)
     return kn ? kn->data : NULL;
 }
 
-void *map_gets(map_t *map, char * skey)
+void *map_gets(map_t *map, char *skey)
 {
     assert(TYPE_CONSISTENT(map, 's'));
 
     struct hash_skey *kn = find_key(map, skey);
     return kn ? kn->data : NULL;
 }
-
-#define map_get(map, key) \
-    _Generic((key), \
-        int: map_geti, \
-        char*: map_gets\
-    )(map, key)\
-
 
 void map_addi(map_t *map, int key, void *data)
 {
@@ -125,15 +146,15 @@ void map_addi(map_t *map, int key, void *data)
     if (kn)
         return;
 
-    kn = (struct hash_key*)malloc(sizeof(struct hash_key));
+    kn = (struct hash_key *) malloc(sizeof(struct hash_key));
     if (!kn)
-        return; 
+        return;
 
     kn->key = key, kn->data = data;
     struct hlist_head *h = &map->ht[hash(key, map->bits)];
     struct hlist_node *n = &kn->node, *first = h->first;
     n->next = first;
-    
+
     if (first)
         first->pprev = &n->next;
     h->first = n;
@@ -147,80 +168,67 @@ void map_adds(map_t *map, char *skey, void *data)
     if (kn)
         return;
 
-    kn = (struct hash_skey*)malloc(sizeof(struct hash_skey));
-    if (!kn) // add
+    kn = (struct hash_skey *) malloc(sizeof(struct hash_skey));
+    if (!kn)  // add
         return;
-    
+
     size_t len = strlen(skey) + 1;
-    kn->skey = (char *)malloc(sizeof(char) * len);
+    kn->skey = (char *) malloc(sizeof(char) * len);
     if (!kn->skey) {
         free(kn);
         return;
     }
 
     strncpy(kn->skey, skey, len);
-    kn->skey[len-1] = '\0';
+    kn->skey[len - 1] = '\0';
     kn->data = data;
     struct hlist_head *h = &map->ht[hash(skey, map->bits)];
     struct hlist_node *n = &kn->node, *first = h->first;
     n->next = first;
-    
+
     if (first)
         first->pprev = &n->next;
     h->first = n;
     n->pprev = &h->first;
 }
 
-#define map_add(map, key, data)  \
-    _Generic((key), \
-        int: map_addi, \
-        char*: map_adds\
-    )(map, key, data)\
-
-
-void map_deli(map_t *map, int key) {
+void map_deli(map_t *map, int key)
+{
     assert(TYPE_CONSISTENT(map, 'i'));
     struct hash_key *kn = find_key(map, key);
     if (!kn)
         return;
-    
+
     struct hlist_node **pprev = kn->node.pprev;
     struct hlist_node *next = kn->node.next;
-    
+
     *pprev = next;
-    if (next) 
+    if (next)
         next->pprev = pprev;
-    
+
     if (kn->data)
         free(kn->data);
     free(kn);
 }
 
-void map_dels(map_t *map, char *skey) {
+void map_dels(map_t *map, char *skey)
+{
     assert(TYPE_CONSISTENT(map, 's'));
     struct hash_skey *kn = find_key(map, skey);
     if (!kn)
         return;
-    
+
     struct hlist_node **pprev = kn->node.pprev;
     struct hlist_node *next = kn->node.next;
-    
+
     *pprev = next;
-    if (next) 
+    if (next)
         next->pprev = pprev;
-    
+
     if (kn->data)
         free(kn->data);
     free(kn);
 }
-
-#define map_del(map, key)  \
-    _Generic((key), \
-        int: map_deli, \
-        char*: map_dels\
-    )(map, key)\
-
-
 
 void map_deinit(map_t *map)
 {
@@ -282,11 +290,7 @@ void map_deinits(map_t *map)
     free(map);
 }
 
-
-
-
-
-/* 
+/*
  * show the information of :
  * 1. load factor
  * 2. bucket non-used ratio
@@ -294,7 +298,8 @@ void map_deinits(map_t *map)
  * 4. bucket more-than-one ratios
  * 5. collision rate
  */
-void map_log_info(map_t *map) {
+void map_log_info(map_t *map)
+{
     if (!map) {
         printf("hash map log info error: hash map is empty.\n");
         return;
@@ -302,28 +307,29 @@ void map_log_info(map_t *map) {
     int b_size = MAP_HASH_SIZE(map->bits);
     int key_cnt = 0, non_cnt = 0, one_cnt = 0, mto_cnt = 0, col_cnt = 0;
 
-    HMAP_FOR_EACH(head, map, i){
+    HMAP_FOR_EACH(head, map, i)
+    {
         int b_cnt = 0;
         HLIST_FOR_EACH(tmp, head)
-            b_cnt++;
+        b_cnt++;
         key_cnt += b_cnt;
         non_cnt += !b_cnt ? 1 : 0;
         one_cnt += b_cnt == 1 ? 1 : 0;
         mto_cnt += b_cnt > 1 ? 1 : 0;
         col_cnt += b_cnt ? (b_cnt - 1) : 0;
     }
-    
+
     printf("============== result ==============\n");
     printf("| num of key = %d\n", key_cnt);
-    printf("| load factor = %f\n", (float)key_cnt / b_size);
-    printf("| not-used rate = %f\n", (float)non_cnt / b_size);
-    printf("| exactly-one rate = %f\n", (float)one_cnt / b_size);
-    printf("| more-than-one rate = %f\n", (float)mto_cnt / b_size);
-    printf("| collision rate = %f\n", (float)col_cnt / key_cnt);
+    printf("| load factor = %f\n", (float) key_cnt / b_size);
+    printf("| not-used rate = %f\n", (float) non_cnt / b_size);
+    printf("| exactly-one rate = %f\n", (float) one_cnt / b_size);
+    printf("| more-than-one rate = %f\n", (float) mto_cnt / b_size);
+    printf("| collision rate = %f\n", (float) col_cnt / key_cnt);
     printf("====================================\n");
 }
 
-/* 
+/*
  * get the information of :
  * 1. load factor
  * 2. bucket non-used ratio
@@ -331,13 +337,15 @@ void map_log_info(map_t *map) {
  * 4. bucket more-than-one ratios
  * 5. collision rate
  */
-struct hmap_info* map_get_info(map_t *map) {
+struct hmap_info *map_get_info(map_t *map)
+{
     if (!map) {
         printf("hash map log info error: hash map is empty.\n");
         return NULL;
     }
 
-    struct hmap_info *ret = (struct hmap_info *)malloc(sizeof(struct hmap_info));
+    struct hmap_info *ret =
+        (struct hmap_info *) malloc(sizeof(struct hmap_info));
     if (!ret) {
         printf("hash map log info error: return value malloc error.\n");
         return NULL;
@@ -346,11 +354,11 @@ struct hmap_info* map_get_info(map_t *map) {
     int b_size = MAP_HASH_SIZE(map->bits);
     int key_cnt = 0, non_cnt = 0, one_cnt = 0, mto_cnt = 0, col_cnt = 0;
 
-
-    HMAP_FOR_EACH(head, map, i){
+    HMAP_FOR_EACH(head, map, i)
+    {
         int b_cnt = 0;
         HLIST_FOR_EACH(tmp, head)
-            b_cnt++;
+        b_cnt++;
         key_cnt += b_cnt;
         non_cnt += !b_cnt ? 1 : 0;
         one_cnt += b_cnt == 1 ? 1 : 0;
@@ -359,12 +367,11 @@ struct hmap_info* map_get_info(map_t *map) {
     }
 
     ret->key_cnt = key_cnt;
-    ret->load_factor = (float)key_cnt / b_size;
-    ret->empty_rate = (float)non_cnt / b_size;
-    ret->exactly_one_rate = (float)one_cnt / b_size;
-    ret->more_than_one_rate = (float)mto_cnt / b_size;
-    ret->collision_rate = (float)col_cnt / key_cnt;
+    ret->load_factor = (float) key_cnt / b_size;
+    ret->empty_rate = (float) non_cnt / b_size;
+    ret->exactly_one_rate = (float) one_cnt / b_size;
+    ret->more_than_one_rate = (float) mto_cnt / b_size;
+    ret->collision_rate = (float) col_cnt / key_cnt;
 
     return ret;
 }
-

--- a/nlp_v.c
+++ b/nlp_v.c
@@ -3,10 +3,11 @@
 #include <time.h>
 #include "hashtable.h"
 
-int main(int argc, char * argv []) {
-
+int main(int argc, char *argv[])
+{
     FILE *fin, *fout;
-    if (!(fin = fopen("dataset/spam.csv", "r")) || !(fout = fopen("dataset/distribution.dat", "w"))) {
+    if (!(fin = fopen("dataset/spam.csv", "r")) ||
+        !(fout = fopen("dataset/distribution.dat", "w"))) {
         printf("dataset load failed.\n");
         exit(EXIT_FAILURE);
     }
@@ -16,7 +17,7 @@ int main(int argc, char * argv []) {
     char msg[248];
     int bits = 16;
 
-    map_t *hmap = map_init(bits, 's'); // 49063 / 65536 ~= 0.76
+    map_t *hmap = map_init(bits, 's');  // 49063 / 65536 ~= 0.76
     if (!hmap) {
         printf("hash map malloc error!\n");
         exit(EXIT_FAILURE);
@@ -27,17 +28,17 @@ int main(int argc, char * argv []) {
 
     for (int i = 0; i < max_i; i++) {
         int s_size = 3 + rand() % 27;
-        char *s = (char *)malloc(sizeof(char) * (s_size + 1));
+        char *s = (char *) malloc(sizeof(char) * (s_size + 1));
         if (s) {
             for (int si = 0; si < s_size; si++)
-                s[si] = (char)(rand() % 92 + 33); 
+                s[si] = (char) (rand() % 92 + 33);
             s[s_size] = '\0';
             printf("key : %s, value = %d\n", s, hash(s, bits));
             map_adds(hmap, s, NULL);
             free(s);
         }
     }
- 
+
     // while (fgets(line, sizeof(line), fin) != NULL) {
 
     //     sscanf(line, "%[^,], %[^\n]", type, msg);
@@ -52,10 +53,11 @@ int main(int argc, char * argv []) {
     //     }
     // }
 
-    HMAP_FOR_EACH(head, hmap, i) {
+    HMAP_FOR_EACH(head, hmap, i)
+    {
         unsigned int cnt = 0;
         HLIST_FOR_EACH(tmp, head)
-            cnt++;
+        cnt++;
         fprintf(fout, "%x\n", cnt);
     }
 

--- a/nlp_v.c
+++ b/nlp_v.c
@@ -56,7 +56,7 @@ int main(int argc, char * argv []) {
         unsigned int cnt = 0;
         HLIST_FOR_EACH(tmp, head)
             cnt++;
-        fprintf(fout, "%i\n", cnt);
+        fprintf(fout, "%x\n", cnt);
     }
 
     map_log_info(hmap);

--- a/nlp_v.c
+++ b/nlp_v.c
@@ -32,7 +32,7 @@ int main(int argc, char * argv []) {
             for (int si = 0; si < s_size; si++)
                 s[si] = (char)(rand() % 92 + 33); 
             s[s_size] = '\0';
-            printf("key : %s, value = %d\n", s, shash(s, bits));
+            printf("key : %s, value = %d\n", s, hash(s, bits));
             map_adds(hmap, s, NULL);
             free(s);
         }

--- a/nlp_v.c
+++ b/nlp_v.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv []) {
     FILE *fin, *fout;
     if (!(fin = fopen("dataset/spam.csv", "r")) || !(fout = fopen("dataset/distribution.dat", "w"))) {
         printf("dataset load failed.\n");
-        exit(0);
+        exit(EXIT_FAILURE);
     }
 
     char line[256];
@@ -19,7 +19,7 @@ int main(int argc, char * argv []) {
     map_t *hmap = map_init(bits, 's'); // 49063 / 65536 ~= 0.76
     if (!hmap) {
         printf("hash map malloc error!\n");
-        exit(0);
+        exit(EXIT_FAILURE);
     }
 
     srand(time(NULL));

--- a/speed.c
+++ b/speed.c
@@ -1,14 +1,14 @@
-#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include "hashtable.h"
 
 #define NINO 1000000000
 
 struct timespec time_diff(struct timespec start, struct timespec end);
 
-int main(int argc, char *argv[]) {
-
+int main(int argc, char *argv[])
+{
     if (argc < 3) {
         printf("should input bits and size.\n");
         exit(0);
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
     for (int i = 0; i < size; i++) {
         _ = hash(i, bits);
     }
-    
+
     clock_gettime(CLOCK_MONOTONIC, &end);
     diff = time_diff(start, end);
     printf("execution time = %lu.%lu sec\n", diff.tv_sec, diff.tv_nsec);
@@ -31,14 +31,15 @@ int main(int argc, char *argv[]) {
     return 0;
 }
 
-struct timespec time_diff(struct timespec start, struct timespec end) {
-  struct timespec temp;
-  if ((end.tv_nsec-start.tv_nsec) < 0) {
-    temp.tv_sec = end.tv_sec - start.tv_sec - 1;
-    temp.tv_nsec = NINO + end.tv_nsec-start.tv_nsec;
-  } else {
-    temp.tv_sec = end.tv_sec-start.tv_sec;
-    temp.tv_nsec = end.tv_nsec-start.tv_nsec;
-  }
-  return temp;
+struct timespec time_diff(struct timespec start, struct timespec end)
+{
+    struct timespec temp;
+    if ((end.tv_nsec - start.tv_nsec) < 0) {
+        temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+        temp.tv_nsec = NINO + end.tv_nsec - start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec - start.tv_sec;
+        temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+    }
+    return temp;
 }


### PR DESCRIPTION
`./hash.h`
Use variable save string length avoid for-loop repeat execute `strlen(str)`, it can reduce time complexity from O(n^2) to O(n).

`./nlp_v.c`
Refactor `exit(0)` function, replace `0` with `EXIT_FAILURE` would be more readable.